### PR TITLE
Allow user to pass final parameter to limit weapon results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ran migration and script on database to add item columns to weapons table
 - Include missing attributes on the /api/v1/weapons endpoint
 ### Added
+- User can provide the final parameter to the weapons endpoint to restrict results to final weapon versions only e.g. /api/v1/weapons?element=Fire&final=1
 - Added badges for build status, maintainability, and test coverage
 - Created a migration and a script to seed the data from items table into the weapons table
 - Advanced URL querying e.g. /api/v1/weapons?element=Fire,Water&wtype=Hunting Horn,Great Sword

--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ Get all Great Swords and Hunting Horns with the Poison or Fire element
 
     http://localhost:3000/api/v1/weapons?wtype=Great Sword,Hunting Horn&element=Poison,Fire
 
+Get only the final version of every Great Sword
+
+    http://localhost:3000/api/v1/weapons?wtype=Great Sword&final=1
+
 ### GET /api/v1/weapons/meta
 A route for obtaining meta level data about MHGU weapons including query parameters and the fields for a Weapon.
 

--- a/app.rb
+++ b/app.rb
@@ -29,7 +29,6 @@ class MHGUQueryApp < Roda
               wtypes = r.params.fetch('wtype', '').split(',')
               elements = r.params.fetch('element', '').split(',')
               final = r.params.fetch('final', nil)
-              puts final
 
               ds = MHGUQuery::Models::Weapon.weapons(
                 wtypes: wtypes,

--- a/app.rb
+++ b/app.rb
@@ -28,9 +28,13 @@ class MHGUQueryApp < Roda
             r.get do
               wtypes = r.params.fetch('wtype', '').split(',')
               elements = r.params.fetch('element', '').split(',')
+              final = r.params.fetch('final', nil)
+              puts final
+
               ds = MHGUQuery::Models::Weapon.weapons(
                 wtypes: wtypes,
                 elements: elements,
+                final: final
               )
               { weapons: ds.map(&:to_hash) }
             end

--- a/lib/mhgu_query/models/weapon.rb
+++ b/lib/mhgu_query/models/weapon.rb
@@ -8,17 +8,22 @@ module MHGUQuery
           join(:items, _id: :_id)
         end
 
+        def final_only
+          where({ final: 1 })
+        end
       end
 
       class << self
 
-        def weapons(wtypes: [], elements: [])
+        def weapons(wtypes: [], elements: [], final: nil)
           ds = dataset
           ds = ds.where({ wtype: wtypes }) unless wtypes.empty?
           unless elements.empty?
             ds = ds.where do
               Sequel.|({ element: elements }, { element_2: elements }) end
           end
+
+          ds = ds.final_only if final
           ds.with_item_details.all
         end
 

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -104,7 +104,6 @@ RSpec.describe MHGUQueryApp do
 
     json["weapons"].each do |w|
       expect(w["final"]).to eq(1)
-      expect(w["wtype"]).to eq("Hunting Horn")
     end
   end
 

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -95,6 +95,32 @@ RSpec.describe MHGUQueryApp do
     expect(found).to all(be true)
   end
 
+  it 'gets the final version of all weapons' do
+    get 'api/v1/weapons', { final: 1 }
+    expect(last_response.status).to eq(200)
+
+    json = JSON.parse(last_response.body)
+    expect(json).to include("weapons")
+
+    json["weapons"].each do |w|
+      expect(w["final"]).to eq(1)
+      expect(w["wtype"]).to eq("Hunting Horn")
+    end
+  end
+
+  it 'gets the final version of one weapon type' do
+    get 'api/v1/weapons', { wtype: "Hunting Horn", final: 1 }
+    expect(last_response.status).to eq(200)
+
+    json = JSON.parse(last_response.body)
+    expect(json).to include("weapons")
+
+    json["weapons"].each do |w|
+      expect(w["final"]).to eq(1)
+      expect(w["wtype"]).to eq("Hunting Horn")
+    end
+  end
+
   it 'gets meta data' do
     get 'api/v1/weapons/meta'
     expect(last_response.status).to eq(200)

--- a/spec/weapon_spec.rb
+++ b/spec/weapon_spec.rb
@@ -11,6 +11,18 @@ RSpec.describe MHGUQuery::Models::Weapon do
     end
   end
 
+  context '#final_only' do
+    it 'only returns the final version of all weapons' do
+      weapons = MHGUQuery::Models::weapon.final_only.all
+      weapons.each do |w|
+        expect(w.final).to be(1)
+      end
+    end
+
+    it 'only returns the final version of a weapon type' do
+    end
+  end
+
   context '#wtype_values' do
     it 'returns the correct types' do
       expected = [

--- a/spec/weapon_spec.rb
+++ b/spec/weapon_spec.rb
@@ -4,6 +4,16 @@ require 'spec_helper'
 
 
 RSpec.describe MHGUQuery::Models::Weapon do
+  context '#weapons' do
+    it 'can get weapons by weapon type' do
+      weapons = MHGUQuery::Models::Weapon.weapons wtypes: ["Hunting Horn"]
+
+      weapon = weapons.first
+      expect(weapon[:name]).not_to be_nil
+      expect(weapon[:description]).not_to be_nil
+    end
+  end
+
   context '#with_item_details' do
     it 'has name and description fields' do
       weapon = MHGUQuery::Models::Weapon.with_item_details.first
@@ -13,7 +23,7 @@ RSpec.describe MHGUQuery::Models::Weapon do
 
   context '#final_only' do
     it 'only returns the final version of all weapons' do
-      weapons = MHGUQuery::Models::weapon.final_only.all
+      weapons = MHGUQuery::Models::Weapon.final_only.all
       weapons.each do |w|
         expect(w.final).to be(1)
       end

--- a/spec/weapon_spec.rb
+++ b/spec/weapon_spec.rb
@@ -30,6 +30,10 @@ RSpec.describe MHGUQuery::Models::Weapon do
     end
 
     it 'only returns the final version of a weapon type' do
+      weapons = MHGUQuery::Models::Weapon.final_only.where({ wtype: "Bow" }).all
+      weapons.each do |w|
+        expect(w.final).to be(1)
+      end
     end
   end
 


### PR DESCRIPTION
This PR allows a user to pass a final parameter into the API that limits weapon results to the final version only.

e.g.
```
http://localhost:3000/api/v1/weapons?wtype=Great Sword&final=1
```